### PR TITLE
Shortened URL moved to its own line

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -75,7 +75,7 @@
             $http.post('/api/shorten', {url: remainder})
               .success(function(data, status, headers, config) {
                 if(data.error) return cb(data.error);
-                else return cb("Url successfully shortened: " + data.shortUrl);
+                else return cb("Url successfully shortened: \n" + data.shortUrl);
               })
               .error(function(data, status, headers, config) {
                 cb("An unknown error occured");


### PR DESCRIPTION
Copying the shortened URL is currently annoying (You can't just double
        click to get the whole line all at once, you have to highlight
        it manually).  This fixes that.
